### PR TITLE
Add --debug --format=standard-verbose to gotestsum options

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -76,7 +76,7 @@ GCI                 := $(TOOLS_BIN_DIR)/gci
 GOTESTSUM           := $(TOOLS_BIN_DIR)/gotestsum
 TESTIFYLINT         := $(TOOLS_BIN_DIR)/testifylint
 
-GOTESTSUM_OPT?= --rerun-fails=1
+GOTESTSUM_OPT?= --debug --format=standard-verbose --rerun-fails=1
 TESTIFYLINT_OPT?= --enable-all --disable=float-compare,formatter,go-require,require-error,suite-subtest-run,useless-assert
 
 # BUILD_TYPE should be one of (dev, release).


### PR DESCRIPTION
Testing if this gives any insight into the `Device or resource busy` issue.
